### PR TITLE
实现DASH模式下的所有分辨率播放（支持音频）

### DIFF
--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -418,7 +418,6 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 						qualityitem["url"] = url;
 						int itag = videos[i]["id"].asInt() *10 +codecid;
 						int trueitag = getTrueItag(itag);
-						qualityitem["codec"] = getCodec(codecid);
 						qualityitem["quality"] = getVideoquality(quality) + getCodec(codecid) ;
 						qualityitem["qualityDetail"] = qualityitem["quality"];
 						qualityitem["itag"] = trueitag;
@@ -431,7 +430,7 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 					dictionary flacqualityitem;
 					flacqualityitem["url"] = data["dash"]["flac"]["audio"]["baseUrl"].asString();
 					flacqualityitem["quality"] = "FLAC" +flacquality;
-					flacqualityitem["qualityDetail"] = "FLAC" ;
+					flacqualityitem["qualityDetail"] = flacqualityitem["quality"];
 					flacqualityitem["itag"] = 258;
 					QualityList.insertLast(flacqualityitem);
 				}
@@ -444,7 +443,7 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 						int audioid = audios[i]["id"].asInt();
 						int audioitag = getAudioItag(audioid);
                         audioqualityitem["url"] = audios[i]["baseUrl"].asString();
-						audioqualityitem["quality"] = getAudioquality(audioid) + " " + audioquality ;
+						audioqualityitem["quality"] =  "AAC " + audioquality ;
 						audioqualityitem["qualityDetail"] = audioqualityitem["quality"] ;
 						audioqualityitem["itag"] = audioitag;
 						QualityList.insertLast(audioqualityitem);
@@ -1304,16 +1303,6 @@ string getVideoquality(int qn) {
 	array<int> qns = {127, 126, 125, 120, 116, 112, 80, 74, 64, 32, 16, 6};
 	array<string> qualities = {"8K 超高清", "杜比视界", "HDR 真彩色", "4K 超清", "1080P60 高帧率", "1080P+ 高码率", "1080P 高清", "720P60 高帧率", "720P 高清", "480P 清晰", "360P 流畅", "240P 极速"};
 	int idx = qns.find(qn);
-	if (idx >= 0) {
-		return qualities[idx];
-	}
-	return "未知";
-}
-
-string getAudioquality(int id) {
-	array<int> ids = {30280, 30232, 30216};
-	array<string> qualities = {"AAC", "AAC", "AAC"};
-	int idx = ids.find(id);
 	if (idx >= 0) {
 		return qualities[idx];
 	}

--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -273,8 +273,7 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 	string url;
 	JsonReader reader;
 	JsonValue root;
-	int defaultQn = 120;
-	int qn = defaultQn;
+	int qn = 127;
 	string quality;
 	string cid;
 	int p = parseInt(parse(path, "p", "1"));
@@ -430,7 +429,6 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 					string flacquality;
 					flacquality = formatFloat(data["dash"]["flac"]["audio"]["bandwidth"].asInt() / 1000.0, "", 0, 1) + "K";
 					dictionary flacqualityitem;
-					int flacitag = 5;
 					flacqualityitem["url"] = data["dash"]["flac"]["audio"]["baseUrl"].asString();
 					flacqualityitem["quality"] = "FLAC" +flacquality;
 					flacqualityitem["qualityDetail"] = "FLAC" ;

--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -23,7 +23,7 @@
 // array<dictionary> PlaylistParse(const string &in)	-> parse playlist
 
 
-bool debug = true;
+bool debug = false;
 string cookie = "";
 int uid = 0;
 bool enable_subtitle = true;


### PR DESCRIPTION
通过对potplayer自带的youtube解析扩展，偶然发现可以通过替换itag的方式实现音频的偷渡挂载，现已实现dash模式下所有分辨率外挂音频播放
我没有c++基础，所以代码都是一步步改出来的，这个PR可以不做合并，还请作者进行优化和完善