### PR TITLE
fix:修复无效链接的播放问题

### DIFF
--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -470,6 +470,9 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 						dictionary qualityitem;
 						int codecid = videos[i]["codecid"].asInt();
 						url = videos[i]["baseUrl"].asString();
+						if(url.find("cn-hncs-gd-bcache-") >= 0){
+							url = videos[i]["backupUrl"][0].asString();
+						}
 						qualityitem["url"] = url;
 						int itag = videos[i]["id"].asInt() * 10 + codecid;
 						int trueitag = getTrueItag(itag);
@@ -497,7 +500,11 @@ string Video(string bvid, const string &in path, dictionary &MetaData, array<dic
 						dictionary audioqualityitem;
 						int audioid = audios[i]["id"].asInt();
 						int audioitag = getAudioItag(audioid);
-                        audioqualityitem["url"] = audios[i]["baseUrl"].asString();
+						string audiourl = audios[i]["baseUrl"].asString();
+						if( audiourl.find("cn-hncs-gd-bcache-") >= 0){
+							audiourl = audios[i]["backupUrl"][0].asString();
+						}
+                        audioqualityitem["url"] = audiourl;
 						audioqualityitem["quality"] =  "AAC " + audioquality;
 						audioqualityitem["qualityDetail"] = audioqualityitem["quality"];
 						audioqualityitem["itag"] = audioitag;


### PR DESCRIPTION
### 修复无效链接的播放问题

#### 问题原因
在部分网络条件下，视频播放链接和音频播放链接的域名会是cn-hncs-gd-bcache-`xx`.bilivideo.com的形式（其中`xx`，我见过 `06`，`07`，`08`等）。  
但是经过[阿里云网站运维检测平台](https://boce.aliyun.com/detect/http)检测，该系列域名几乎不可连接。  
[以08域名为例](https://boce.aliyun.com/detect/http/7e3c1a92f7834c76a6a3c5dc99823f7b)  
出现该问题的原因，我认为有很大可能在于运营商。我使用广电的流量时极易出现该问题，使用其他运营商则不会。  


#### 问题修复
当检测到视频播放链接和音频播放链接的域名中，含有`cn-hncs-gd-bcache-`字串时，认为获取到无效无链接，此时使用备用链接代替该无效链接。


#### 潜在问题
其实应该直接检测链接是否有效的。但是我对该语言和potplayer都不够熟悉，有心无力。

