### PR TITLE
fix:修复父区域id不匹配和起始页数问题，并设置直播间最大数量

### DIFF
--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -1092,7 +1092,7 @@ array<dictionary> liveCategory(uint page,string cateid,string parentAreaId) {
 					video["author"] = item["uname"].asString();
 					videos.insertLast(video);
 				}
-				if (page < 2) {
+				if ((page - 1) * list.size() < 200) {
 					array<dictionary> videos2 = liveCategory(page+1,cateid,parentAreaId);
 					for (uint i = 0; i < videos2.size(); i++) {
 						videos.insertLast(videos2[i]);
@@ -1844,13 +1844,13 @@ array<dictionary> PlaylistParse(const string &in path) {
 	}
 	if(path.find("live.bilibili.com") >= 0) {
 		if(path.find("areaId") >= 0){
-			return liveCategory(1,HostRegExpParse(path, "areaId=([0-9]+)"),"2");
+			return liveCategory(2,HostRegExpParse(path, "areaId=([0-9]+)"), HostRegExpParse(path, "parentAreaId=([0-9]+)"));
 		}
 		if(path.find("lol") >= 0){
-			return liveCategory(1,"86","2");
+			return liveCategory(2,"86","2");
 		}
 		if(path.find("hpjy") >= 0){
-			return liveCategory(1,"256","3");
+			return liveCategory(2,"256","3");
 		}
 	}
 	if (path.find("www.bilibili.com") >= 0 && HostRegExpParse(path, "www.bilibili.com/([a-zA-Z0-9]+)").empty()) {


### PR DESCRIPTION
父区域id是直播分类id，获取游戏直播间列表应该要自动获取
`parent_area_id=xx`
![image](https://github.com/user-attachments/assets/53995992-dd06-4db0-91da-e11da1f25901)
![image](https://github.com/user-attachments/assets/2997e827-846e-45d2-8c7f-5634b0aa8151)
并设置修正了page页数bug。从1开始会有重复。2应该就是完整的。
**已知问题**：potplayer的直播间顺序有可能会和web网页的不一致。
还设置了最大直播间数量，每个page的列表数量不是20就是40，所以取了公倍数 200。
有问题再修😣