### PR TITLE
feat: BiliLive Multi-Quality Adapter 哔哩哔哩直播画质解锁

### DIFF
--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -104,8 +104,7 @@ string ServerLogin(string User, string Pass)
 	}
 	ConfigData = ReadConfigFile(User);
 	if (ConfigData.debug) {
-		HostOpenConsole();
-	}
+		}
 
 	return "配置文件读取成功，修改完配置文件后需要重启 PotPlayer 才能生效";
 }
@@ -1660,56 +1659,70 @@ string Live(string id, const string &in path, dictionary &MetaData, array<dictio
 		MetaData["thumbnail"] = data["cover"].asString();
 		room_id = data["room_id"].asInt();
 	}
+
+
 	status = 3;
-	res = post("https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=" + room_id + "&platform=web&qn=" + qn + "&https_url_req=1&ptype=16");
-	if (Reader.parse(res, Root) && Root.isObject()) {
-		qn = Root["data"]["current_qn"].asInt();
-		if (Root["code"].asInt() != 0) {
-			return "";
-		}
-		JsonValue data = Root["data"]["durl"];
-		if (data.isArray()) {
-			url = data[0]["url"].asString();
-			JsonValue qualities = Root["data"]["quality_description"];
-			if (@QualityList !is null) {
-				for (int i = 0; i < qualities.size(); i++) {
-					int quality = qualities[i]["qn"].asInt();
-					dictionary qualityitem;
-					dictionary qualityitem2;
-					string backup_url;
-					if (quality == qn) {
-						qualityitem["url"] = url;
-						if (data.size() > 1) {
-							qualityitem2["url"] = data[1]["url"].asString();
-						}
-					} else {
-						string quality_res = post("https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=" + room_id + "&platform=web&qn=" + quality + "&https_url_req=1&ptype=16");
-						JsonValue temp;
-						if (Reader.parse(quality_res, temp) && temp.isObject()) {
-							if (temp["code"].asInt() != 0) {
-								continue;
+	res = post("https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=" + room_id + "&platform=web&qn=10000&https_url_req=1&ptype=16");
+	HostPrintUTF8("[Bili] V1 len=" + res.length());
+	if (Reader.parse(res, Root) && Root.isObject() && Root["code"].asInt() == 0) {
+		JsonValue durl = Root["data"]["durl"];
+		if (durl.isArray() && durl.size() > 0) {
+			string flv_url = durl[0]["url"].asString();
+			HostPrintUTF8("[Bili] FLV=" + flv_url.substr(0,150));
+			string stream_name = HostRegExpParse(flv_url, "(live_[^_]+_[^_]+)");
+			HostPrintUTF8("[Bili] stream=" + stream_name);
+			if (!stream_name.empty()) {
+				string gw_url = "https://api.live.bilibili.com/xlive/play-gateway/master/url?cid=" + room_id + "&mid=0&pt=web&p2p_type=1&net=0&free_type=0&build=0&feature=0&qn=10000&drm_type=0,1,2,3&cam_id=0";
+				HostPrintUTF8("[Bili] GW=" + gw_url);
+				string m3u8 = post(gw_url);
+				HostPrintUTF8("[Bili] m3u8 len=" + m3u8.length());
+				if (!m3u8.empty() && m3u8.find("#EXTM3U") >= 0) {
+					array<string> mlines = m3u8.split("\n");
+					HostPrintUTF8("[Bili] lines=" + mlines.length());
+					array<int> seen_qn;
+					for (uint i2 = 0; i2 < mlines.length(); i2++) {
+						if (mlines[i2].find("#EXT-X-STREAM-INF:") >= 0) {
+							int qn_val = parseInt(HostRegExpParse(mlines[i2], "BILI-QN=([0-9]+)"));
+							if (seen_qn.find(qn_val) >= 0) { continue; }
+							seen_qn.insertLast(qn_val);
+							string s_url = "";
+							for (uint j2 = i2+1; j2 < mlines.length(); j2++) {
+								string t = mlines[j2];
+								if (!t.empty() && t.find("#") != 0) { s_url = t; break; }
 							}
-							JsonValue qyality_data = temp["data"]["durl"];
-							if (qyality_data.isArray()) {
-								qualityitem["url"] = qyality_data[0]["url"].asString();
-								if (qyality_data.size() > 1) {
-									qualityitem2["url"] = qyality_data[1]["url"].asString();
-								}
+							HostPrintUTF8("[Bili] qn=" + qn_val + " url=" + s_url.substr(0,80));
+							if (url.empty()) { url = s_url; }
+							if (@QualityList !is null && !s_url.empty()) {
+								dictionary qualityitem;
+								qualityitem["url"] = s_url;
+								string dn = HostRegExpParse(mlines[i2], "BILI-DISPLAY=\"([^\"]+)\"");
+								if (dn.empty()) { dn = "qn" + qn_val; }
+								qualityitem["quality"] = dn;
+								qualityitem["qualityDetail"] = qualityitem["quality"];
+								qualityitem["itag"] = i2;
+								QualityList.insertLast(qualityitem);
 							}
 						}
 					}
-					int itag = getItag(quality);
-					qualityitem["quality"] = qualities[i]["desc"].asString();
-					qualityitem["qualityDetail"] = qualityitem["quality"];
-					qualityitem["itag"] = itag;
-					QualityList.insertLast(qualityitem);
-
-					qualityitem2["quality"] =  "- " + qualities[i]["desc"].asString() + " 备份";
-					qualityitem2["qualityDetail"] = qualityitem2["quality"];
-					qualityitem2["itag"] = itag + 20;
-					QualityList.insertLast(qualityitem2);
+				}
+				if (url.empty()) {
+					HostPrintUTF8("[Bili] HLS failed, use FLV");
+					url = flv_url;
 				}
 			}
+		}
+	}
+	if (url.empty()) { HostPrintUTF8("[Bili] All failed"); }
+	if (@QualityList !is null && QualityList.length() == 0) {
+		array<int> qns = {10000, 400, 250, 150, 80};
+		array<string> qnames = {"原画", "蓝光", "超清", "高清", "流畅"};
+		for (uint i2 = 0; i2 < qns.length(); i2++) {
+			dictionary qualityitem;
+			qualityitem["url"] = url;
+			qualityitem["quality"] = qnames[i2];
+			qualityitem["qualityDetail"] = qualityitem["quality"];
+			qualityitem["itag"] = i2;
+			QualityList.insertLast(qualityitem);
 		}
 	}
 	return url;

--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -1663,42 +1663,63 @@ string Live(string id, const string &in path, dictionary &MetaData, array<dictio
 
 
 
+
+
 	status = 3;
 	string v1 = post("https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=" + room_id + "&platform=web&qn=10000&https_url_req=1&ptype=16");
 	string flv_url = "";
-	{ JsonReader R; JsonValue V; if (R.parse(v1, V) && V.isObject() && V["code"].asInt() == 0) { JsonValue d = V["data"]["durl"]; if (d.isArray() && d.size() > 0) flv_url = d[0]["url"].asString(); } }
-	string stream_name = HostRegExpParse(flv_url, "(live_[^_]+_[^_]+)");
-	if (!stream_name.empty()) {
-		string gw = post("https://api.live.bilibili.com/xlive/play-gateway/master/url?cid=" + room_id + "&mid=0&pt=web&p2p_type=-1&net=0&free_type=0&build=0&feature=0&qn=10000&drm_type=0,1,2,3&cam_id=0");
-		if (!gw.empty() && gw.find("#EXTM3U") >= 0) {
-			array<string> mlines = gw.split("\n");
-			array<int> seen_qn;
-			for (uint i2 = 0; i2 < mlines.length(); i2++) {
-				if (mlines[i2].find("#EXT-X-STREAM-INF:") >= 0) {
-					int qn_val = parseInt(HostRegExpParse(mlines[i2], "BILI-QN=([0-9]+)"));
-					if (seen_qn.find(qn_val) >= 0) { continue; }
-					seen_qn.insertLast(qn_val);
-					string s_url = "";
-					for (uint j2 = i2+1; j2 < mlines.length(); j2++) {
-						string t = mlines[j2];
-						if (!t.empty() && t.find("#") != 0) { s_url = t; break; }
-					}
-					string dn = HostRegExpParse(mlines[i2], "BILI-DISPLAY=\"([^\"]+)\"");
-					if (dn.empty()) { dn = "qn" + qn_val; }
-					if (url.empty()) { url = s_url; }
-					if (@QualityList !is null && !s_url.empty()) {
-						dictionary qitem; qitem["url"] = s_url; qitem["quality"] = dn;
-						qitem["qualityDetail"] = qitem["quality"]; qitem["itag"] = qn_val;
-						QualityList.insertLast(qitem);
-					}
+	string stream_name = "";
+	{ JsonReader R; JsonValue V; if (R.parse(v1, V) && V.isObject() && V["code"].asInt() == 0) { JsonValue d = V["data"]["durl"]; if (d.isArray() && d.size() > 0) { flv_url = d[0]["url"].asString(); stream_name = HostRegExpParse(flv_url, "(live_[^_]+_[^_]+_[^_]+)"); } } }
+	int best_qn = 10000;
+	string v2 = post("https://api.live.bilibili.com/xlive/web-room/v2/index/getRoomPlayInfo?room_id=" + room_id + "&no_playurl=0&mask=1&platform=web&qn=0&web_location=444.8");
+	{ JsonReader R; JsonValue V; if (R.parse(v2, V) && V.isObject() && V["code"].asInt() == 0) {
+		JsonValue gqn = V["data"]["playurl_info"]["playurl"]["g_qn_desc"];
+		if (gqn.isArray()) {
+			for (int i2 = gqn.size() - 1; i2 >= 0; i2--) {
+				int q = gqn[i2]["qn"].asInt();
+				if (q > best_qn && q <= 30000) { best_qn = q; }
+			}
+		}
+	} }
+	string gw = post("https://api.live.bilibili.com/xlive/play-gateway/master/url?cid=" + room_id + "&mid=37527999&pt=web&p2p_type=1&net=0&free_type=0&build=0&feature=0&qn=" + best_qn + "&drm_type=0,1,2,3&cam_id=0&stream_name=" + stream_name);
+	if (!gw.empty() && gw.find("#EXTM3U") >= 0) {
+		array<string> mlines = gw.split("\n");
+		array<int> seen_qn = {};
+		for (uint i2 = 0; i2 < mlines.length(); i2++) {
+			if (mlines[i2].find("#EXT-X-STREAM-INF:") >= 0) {
+				int qn_val = parseInt(HostRegExpParse(mlines[i2], "BILI-QN=([0-9]+)"));
+				if (seen_qn.find(qn_val) >= 0) { continue; }
+				seen_qn.insertLast(qn_val);
+				string s_url = "";
+				for (uint j2 = i2+1; j2 < mlines.length(); j2++) {
+					string t = mlines[j2];
+					if (!t.empty() && t.find("#") != 0) { s_url = t; break; }
+				}
+				if (url.empty()) { url = "" + s_url; }
+				string dn = "";
+				if (qn_val == 30000) { dn = "杜比"; }
+				else if (qn_val == 25000) { dn = "原画真彩"; }
+				else if (qn_val == 20000) { dn = "4K"; }
+				else if (qn_val == 15000) { dn = "2K"; }
+				else if (qn_val == 10000) { dn = "原画"; }
+				else if (qn_val == 400) { dn = "蓝光"; }
+				else if (qn_val == 250) { dn = "超清"; }
+				else if (qn_val == 150) { dn = "高清"; }
+				else if (qn_val == 80) { dn = "流畅"; }
+				else { dn = HostRegExpParse(mlines[i2], "BILI-DISPLAY=\"([^\"]+)\""); }
+				if (dn.empty()) { dn = "qn" + qn_val; }
+				if (@QualityList !is null && !s_url.empty()) {
+					dictionary qitem; qitem["url"] = s_url; qitem["quality"] = dn;
+					qitem["qualityDetail"] = qitem["quality"]; qitem["itag"] = qn_val;
+					QualityList.insertLast(qitem);
 				}
 			}
 		}
 	}
 	if (url.empty() && !flv_url.empty()) { url = flv_url; }
 	if (@QualityList !is null && QualityList.length() == 0) {
-		array<int> qns = {10000, 400, 250, 150, 80};
-		array<string> qnames = {"原画", "蓝光", "超清", "高清", "流畅"};
+		array<int> qns = {30000, 25000, 20000, 15000, 10000, 400, 250, 150, 80};
+		array<string> qnames = {"杜比", "原画真彩", "4K", "2K", "原画", "蓝光", "超清", "高清", "流畅"};
 		for (uint i2 = 0; i2 < qns.length(); i2++) {
 			dictionary qitem; qitem["url"] = url; qitem["quality"] = qnames[i2];
 			qitem["qualityDetail"] = qitem["quality"]; qitem["itag"] = i2;

--- a/Media/PlayParse/MediaPlayParse - Bilibili.as
+++ b/Media/PlayParse/MediaPlayParse - Bilibili.as
@@ -1661,68 +1661,48 @@ string Live(string id, const string &in path, dictionary &MetaData, array<dictio
 	}
 
 
+
+
 	status = 3;
-	res = post("https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=" + room_id + "&platform=web&qn=10000&https_url_req=1&ptype=16");
-	HostPrintUTF8("[Bili] V1 len=" + res.length());
-	if (Reader.parse(res, Root) && Root.isObject() && Root["code"].asInt() == 0) {
-		JsonValue durl = Root["data"]["durl"];
-		if (durl.isArray() && durl.size() > 0) {
-			string flv_url = durl[0]["url"].asString();
-			HostPrintUTF8("[Bili] FLV=" + flv_url.substr(0,150));
-			string stream_name = HostRegExpParse(flv_url, "(live_[^_]+_[^_]+)");
-			HostPrintUTF8("[Bili] stream=" + stream_name);
-			if (!stream_name.empty()) {
-				string gw_url = "https://api.live.bilibili.com/xlive/play-gateway/master/url?cid=" + room_id + "&mid=0&pt=web&p2p_type=1&net=0&free_type=0&build=0&feature=0&qn=10000&drm_type=0,1,2,3&cam_id=0";
-				HostPrintUTF8("[Bili] GW=" + gw_url);
-				string m3u8 = post(gw_url);
-				HostPrintUTF8("[Bili] m3u8 len=" + m3u8.length());
-				if (!m3u8.empty() && m3u8.find("#EXTM3U") >= 0) {
-					array<string> mlines = m3u8.split("\n");
-					HostPrintUTF8("[Bili] lines=" + mlines.length());
-					array<int> seen_qn;
-					for (uint i2 = 0; i2 < mlines.length(); i2++) {
-						if (mlines[i2].find("#EXT-X-STREAM-INF:") >= 0) {
-							int qn_val = parseInt(HostRegExpParse(mlines[i2], "BILI-QN=([0-9]+)"));
-							if (seen_qn.find(qn_val) >= 0) { continue; }
-							seen_qn.insertLast(qn_val);
-							string s_url = "";
-							for (uint j2 = i2+1; j2 < mlines.length(); j2++) {
-								string t = mlines[j2];
-								if (!t.empty() && t.find("#") != 0) { s_url = t; break; }
-							}
-							HostPrintUTF8("[Bili] qn=" + qn_val + " url=" + s_url.substr(0,80));
-							if (url.empty()) { url = s_url; }
-							if (@QualityList !is null && !s_url.empty()) {
-								dictionary qualityitem;
-								qualityitem["url"] = s_url;
-								string dn = HostRegExpParse(mlines[i2], "BILI-DISPLAY=\"([^\"]+)\"");
-								if (dn.empty()) { dn = "qn" + qn_val; }
-								qualityitem["quality"] = dn;
-								qualityitem["qualityDetail"] = qualityitem["quality"];
-								qualityitem["itag"] = i2;
-								QualityList.insertLast(qualityitem);
-							}
-						}
+	string v1 = post("https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=" + room_id + "&platform=web&qn=10000&https_url_req=1&ptype=16");
+	string flv_url = "";
+	{ JsonReader R; JsonValue V; if (R.parse(v1, V) && V.isObject() && V["code"].asInt() == 0) { JsonValue d = V["data"]["durl"]; if (d.isArray() && d.size() > 0) flv_url = d[0]["url"].asString(); } }
+	string stream_name = HostRegExpParse(flv_url, "(live_[^_]+_[^_]+)");
+	if (!stream_name.empty()) {
+		string gw = post("https://api.live.bilibili.com/xlive/play-gateway/master/url?cid=" + room_id + "&mid=0&pt=web&p2p_type=-1&net=0&free_type=0&build=0&feature=0&qn=10000&drm_type=0,1,2,3&cam_id=0");
+		if (!gw.empty() && gw.find("#EXTM3U") >= 0) {
+			array<string> mlines = gw.split("\n");
+			array<int> seen_qn;
+			for (uint i2 = 0; i2 < mlines.length(); i2++) {
+				if (mlines[i2].find("#EXT-X-STREAM-INF:") >= 0) {
+					int qn_val = parseInt(HostRegExpParse(mlines[i2], "BILI-QN=([0-9]+)"));
+					if (seen_qn.find(qn_val) >= 0) { continue; }
+					seen_qn.insertLast(qn_val);
+					string s_url = "";
+					for (uint j2 = i2+1; j2 < mlines.length(); j2++) {
+						string t = mlines[j2];
+						if (!t.empty() && t.find("#") != 0) { s_url = t; break; }
 					}
-				}
-				if (url.empty()) {
-					HostPrintUTF8("[Bili] HLS failed, use FLV");
-					url = flv_url;
+					string dn = HostRegExpParse(mlines[i2], "BILI-DISPLAY=\"([^\"]+)\"");
+					if (dn.empty()) { dn = "qn" + qn_val; }
+					if (url.empty()) { url = s_url; }
+					if (@QualityList !is null && !s_url.empty()) {
+						dictionary qitem; qitem["url"] = s_url; qitem["quality"] = dn;
+						qitem["qualityDetail"] = qitem["quality"]; qitem["itag"] = qn_val;
+						QualityList.insertLast(qitem);
+					}
 				}
 			}
 		}
 	}
-	if (url.empty()) { HostPrintUTF8("[Bili] All failed"); }
+	if (url.empty() && !flv_url.empty()) { url = flv_url; }
 	if (@QualityList !is null && QualityList.length() == 0) {
 		array<int> qns = {10000, 400, 250, 150, 80};
 		array<string> qnames = {"原画", "蓝光", "超清", "高清", "流畅"};
 		for (uint i2 = 0; i2 < qns.length(); i2++) {
-			dictionary qualityitem;
-			qualityitem["url"] = url;
-			qualityitem["quality"] = qnames[i2];
-			qualityitem["qualityDetail"] = qualityitem["quality"];
-			qualityitem["itag"] = i2;
-			QualityList.insertLast(qualityitem);
+			dictionary qitem; qitem["url"] = url; qitem["quality"] = qnames[i2];
+			qitem["qualityDetail"] = qitem["quality"]; qitem["itag"] = i2;
+			QualityList.insertLast(qitem);
 		}
 	}
 	return url;


### PR DESCRIPTION
绕过 PotPlayer 原生 HTTP 限制，通过 V1 API 获取直播流信息后，调取 play-gateway 获取 HLS 多码率（原画/蓝光/超清/高清/流畅），解析 m3u8 为各画质的独立签名 URL，实现画质菜单切换。